### PR TITLE
Add check for NODE_ENV === 'development'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 const isCI = require('is-ci')
 
+const { DEBUG, NODE_ENV = 'development' } = process.env
+
 const env = {
-  test: Boolean(process.env.NODE_ENV === 'test'),
-  dev: Boolean(process.env.NODE_ENV === 'dev'),
-  production: Boolean(process.env.NODE_ENV === 'production'),
-  debug: Boolean(process.env.DEBUG),
+  test: NODE_ENV === 'test',
+  dev: NODE_ENV === 'development' || NODE_ENV === 'dev',
+  production: NODE_ENV === 'production',
+  debug: Boolean(DEBUG),
   ci: Boolean(isCI),
   tty: Boolean(process.stdout.isTTY),
   minimalCLI: undefined


### PR DESCRIPTION
- Bring environment vars in to scope.
- Unwrap `Boolean()` when it's not needed.
- Default `NODE_ENV` to `"development"` when it's not defined.